### PR TITLE
feat: add a screenshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The packager consists of the following features:
 - rekey the Roku device with given signed package
 - generate a package ready to upload to the Roku channel
 - prepare and build an app for the Visual Studio Code [extension](https://github.com/RokuCommunity/vscode-brightscript-language)
+- take a screenshot of the dev app
 
 ## Listing
 - [Prerequisites](#prerequisites)
@@ -73,6 +74,7 @@ The main configuration file `.kopytkorc` should be placed in the root folder of 
   "signedPackagePath": "/previous/signed.pkg",
   "baseManifest": "/manifest/base.js",
   "localManifestOverride": "/manifest/local.${args.env}.js",
+  "screenshotDir": "/dist",
   "pluginDefinitions": {},
   "plugins": [],
   "sourceDir": "/app",
@@ -95,6 +97,7 @@ Available fields:
 - `generatedPackagePath [@type string @optional]` - path to the app package to generate; default value as in the example file above
 - `baseManifest [@type string @required]` - base manifest file path. Having the file is sufficient to run the Roku app
 - `localManifestOverride [@type string @optional]` - path to the configuration file that overrides all other settings. Usually the file is on the git ignore list
+- `screenshotDir [@type string @optional]` - the directory where screenshots will be saved; default value as in the example file above
 - `pluginDefinitions [@type [name: string]:object @optional]` - plugin definitions (see [plugins](#plugins))
 - `plugins @optional` - global plugins list (see [plugins](#plugins))
 - `environments [@type [name: string]:object @optional]` - list of environments. The name should correspond to the `ENV` value. Each environment entry consists of:
@@ -116,6 +119,7 @@ The packager contains the following scripts:
 - `scripts/start.js` - builds and deploys the app to the device
 - `scripts/generate-package.js` - rekey device if needed, builds, deploys the app to the device and finally signs and download the package
 - `scripts/prepare-for-vsc.js` - helpful when using debugging protocol in the VSC [extension](https://github.com/RokuCommunity/vscode-brightscript-language)
+- `scripts/screenshot.js` - takes a screenshot of the current dev application (works only with dev channel), screenshot file name - `Screenshot_<Date as ISOString>.jpg`
 
 Example usage:
 ```json
@@ -126,7 +130,7 @@ Example usage:
 ```
 
 Available parameters:
-- `env` - your environment value that matches entry in the [.kopytkorc](#.kopytkorc-file) file. Default value (if not passed) is "dev"
+- `env` - your environment value that matches entry in the [.kopytkorc](#configuration) file. Default value (if not passed) is "dev"
 - `rokuDevPassword` - dev password
 - `rokuDevUser` - dev user
 - `rokuDevId` - dev id, needed to rekey the device

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,0 +1,7 @@
+const StepRunner = require('../src/step-runner/step-runner');
+const ScreenshotStep = require('../src/step-runner/steps/screenshot/screenshot-step');
+const screenshotStepConfig = require('../src/step-runner/steps/screenshot/screenshot-step-config');
+
+new StepRunner([
+  { step: ScreenshotStep, config: screenshotStepConfig },
+]).run();

--- a/src/config.js
+++ b/src/config.js
@@ -15,6 +15,7 @@ module.exports = {
   generatedPackagePath: '/dist/kopytko_package.pkg',
   externalModulesDirName: 'kopytko_modules',
   kopytkorcFilename: '.kopytkorc',
+  screenshotDir: '/dist',
   sourceDir: '/app',
   tempDir,
 };

--- a/src/core/screenshot-taker.js
+++ b/src/core/screenshot-taker.js
@@ -1,0 +1,82 @@
+const fs = require('fs-extra');
+const path = require('path');
+const request = require('request-promise');
+
+const KopytkoError = require('../errors/kopytko-error');
+
+module.exports = class ScreenshotTaker {
+  _SCREENSHOT_URI_PATH = /"(pkgs\/dev\.jpg\?time=\d+)">/;
+
+  _config = {};
+
+  /**
+   * @param  {Object} config
+   * @param  {String} config.rokuIP
+   * @param  {String} config.rokuDevPassword
+   * @param  {String} config.rokuDevUser
+   * @param  {String} config.screenshotDir
+   */
+  constructor(config) {
+    this._config = config;
+  }
+
+  async takeScreenshot() {
+    try {
+      const response = await this._sendRequest({
+        action: 'Screenshot',
+        ...this._config,
+      });
+
+      const [, screenshotUriPath] = response.body.match(this._SCREENSHOT_URI_PATH) || [];
+
+      if (screenshotUriPath) {
+        await fs.ensureDir(this._config.screenshotDir);
+
+        return new Promise(resolve => {
+          const screenshotFilePath = path.join(this._config.screenshotDir, `Screenshot_${new Date().toISOString()}.jpg`)
+          const file = fs.createWriteStream(screenshotFilePath);
+
+          file.on('finish', resolve);
+
+          this._downloadScreenshot({
+            screenshotUri: `http://${this._config.rokuIP}/${screenshotUriPath}`,
+            ...this._config,
+          })
+            .pipe(file);
+        });
+      }
+
+      throw new KopytkoError('Something went wrong. Check if Roku does not have a screen saver on.');
+    } catch (error) {
+      throw new KopytkoError(`Unknown error. HTTP status code: ${error.statusCode}`, error);
+    }
+  }
+
+  _sendRequest({ action, rokuIP, rokuDevPassword, rokuDevUser }) {
+    return request({
+      method: 'POST',
+      uri: `http://${rokuIP}/plugin_inspect`,
+      formData: {
+        mysubmit: action,
+      },
+      auth: {
+        user: rokuDevUser,
+        pass: rokuDevPassword,
+        sendImmediately: false,
+      },
+      resolveWithFullResponse: true,
+    });
+  }
+
+  _downloadScreenshot({ rokuDevUser, rokuDevPassword, screenshotUri }) {
+    return request({
+      method: 'GET',
+      uri: screenshotUri,
+      auth: {
+        user: rokuDevUser,
+        pass: rokuDevPassword,
+        sendImmediately: false,
+      },
+    });
+  }
+}

--- a/src/env/kopytko-config.js
+++ b/src/env/kopytko-config.js
@@ -43,6 +43,7 @@ module.exports = {
   manifest,
   pluginDefinitions: kopytkorc.getPluginDefinitions(),
   pluginNames: getPluginNames(),
+  screenshotDir: kopytkorc.getScreenshotDir(),
   sourceDir: kopytkorc.getSourceDir(args.env),
   tempDir: kopytkorc.getTempDir(args.env),
 };

--- a/src/env/kopytkorc-reader.js
+++ b/src/env/kopytkorc-reader.js
@@ -28,6 +28,10 @@ module.exports = class KopytkorcReader {
     return this._getConfigField(env, "localManifestOverride");
   }
 
+  getScreenshotDir() {
+    return this._getConfigField(this._DEFAULT_ENV, "screenshotDir");
+  }
+
   getSourceDir(env) {
     return this._getConfigField(env, "sourceDir");
   }

--- a/src/step-runner/steps/screenshot/screenshot-step-config.js
+++ b/src/step-runner/steps/screenshot/screenshot-step-config.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+const args = require('../../../env/args');
+const kopytkoConfig = require('../../../env/kopytko-config');
+
+module.exports = {
+  rokuIP: args.rokuIP,
+  rokuDevPassword: args.rokuDevPassword,
+  rokuDevUser: args.rokuDevUser,
+  screenshotDir: path.join(process.env.PWD, kopytkoConfig.screenshotDir),
+}

--- a/src/step-runner/steps/screenshot/screenshot-step.js
+++ b/src/step-runner/steps/screenshot/screenshot-step.js
@@ -1,0 +1,23 @@
+const ScreenshotTaker = require('../../../core/screenshot-taker');
+const Step = require('../step');
+
+module.exports = class ScreenshotStep extends Step {
+  static TITLE = 'Screenshot';
+
+  /**
+   * Takes a screenshot of current .
+   *
+   * @param {Object} config
+   * @param {String} config.rokuIP
+   * @param {String} config.rokuDevUser
+   * @param {String} config.rokuDevPassword
+   * @param {String} config.screenshotDir
+   */
+  async run({ rokuIP, rokuDevUser, rokuDevPassword, screenshotDir }) {
+    const screenshotTaker = new ScreenshotTaker({ rokuIP, rokuDevUser, rokuDevPassword, screenshotDir });
+
+    this.logger.subStep('Taking a screenshot');
+
+    return screenshotTaker.takeScreenshot();
+  }
+}


### PR DESCRIPTION
`Screenshot` script that takes a screenshot of the dev app.
Screenshots are saved under the screenshotDir path from .kopytkorc or if such field is not provided the default directory is set to `/dist`.
The script saves it under filename `Screenshot_<Date as ISOString>.jpg`

Requirements:
- Roku device needs to have the dev app uploaded and opened.
- The screen saver is NOT on the screen.

## Todos:

- [x] Write documentation (if required)
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
