### PR TITLE
fix: rokuDevPassword being treated as number

### DIFF
--- a/src/core/app-deployer.js
+++ b/src/core/app-deployer.js
@@ -41,7 +41,7 @@ module.exports = class AppDeployer {
       return messages.join(' ');
     } catch (error) {
       if (error.statusCode === 401) {
-        throw new KopytkoError('Bad Roku Developer credentials. Check ROKU_DEV_PASSWORD and ROKU_USER in .env file');
+        throw new KopytkoError('Bad Roku Developer credentials. Check ROKU_DEV_PASSWORD and ROKU_DEV_USER in .env file');
       }
 
       if (error.statusCode === 577) {

--- a/src/env/args.js
+++ b/src/env/args.js
@@ -124,6 +124,7 @@ const parsedArgs = minimist(args, {
      */
     forceHttp: process.env.FORCE_HTTP === 'true',
   },
+  string: [ 'rokuDevPassword' ],
 });
 
 module.exports = parsedArgs;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/getndazn/kopytko-packager/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

Whilst attempting to run https://github.com/getndazn/kopytko-utils#running-unit-tests, I noticed that if the Roku device has a numerical password, deployment fails due to the password being parsed as a number.

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Per [minimist documentation](https://github.com/minimistjs/minimist#var-argv--parseargsargs-opts)

> Numeric-looking arguments will be returned as numbers unless opts.string or opts.boolean is set for that argument name.

Hence, using the `string` option provided to explicitly parse `rokuDevPassword` arg value as a string.

## How can we verify it:

<!--
Add any applicable config, projects, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* .kopytkorc config file of an example app
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

- [ ] ~Write documentation (if required)~
- [x] Fix linting errors
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
